### PR TITLE
Remove example code from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,3 @@ Arduino library to send Morse Code dots and dashes on a specified pin.
 This is a simple Arduino library used to demonstrate how you can extend the functionality of Arduino.
 
 This library example is used in the [Writing a Library for Arduino tutorial](https://docs.arduino.cc/learn/contributions/arduino-creating-library-guide).
-
-## Example
-
-Here is an example sketch used to send the SOS distress call.
-
-```cpp
-#include "Morse.h"
-
-Morse morse(13);
-
-void setup()
-{
-  morse.begin(); 
-}
-
-void loop()
-{
-  morse.dot(); morse.dot(); morse.dot();
-  morse.dash(); morse.dash(); morse.dash();
-  morse.dot(); morse.dot(); morse.dot();
-  delay(3000);
-}
-```


### PR DESCRIPTION
The code is already present in the "SOS" example sketch.

Having duplicated content is a maintenance liability because it is likely that one copy or the other will be forgotten when making future changes, resulting in the two falling out of sync with each other and missing out on enhancements or corrections.