### PR TITLE
Use most appropriate #include syntax in example

### DIFF
--- a/examples/SOS/SOS.ino
+++ b/examples/SOS/SOS.ino
@@ -1,4 +1,4 @@
-#include "Morse.h"
+#include <Morse.h>
 
 Morse morse(13);
 


### PR DESCRIPTION
The angle bracket `#include` directive syntax causes the include search path and libraries folders to be searched for the file.

The double quote syntax causes the path relative to the containing file to be searched, followed by the same paths as the angle bracket syntax.

https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html

So either of these syntaxes will work for `#include` directives of a library header file, but the angle bracket syntax communicates that intent. The angle bracket syntax also avoids the possibility of a sketch file being discovered instead of the target library file.

Admittedly, the benefits of using the angle bracket syntax in this case are not overwhelming, but this example sketch may serve as a reference for the creation of many other example sketches created by those who learn from the tutorial, and those example sketches may serve as a reference for many other sketches written by those who learn from the examples.